### PR TITLE
Add missing types

### DIFF
--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -11791,8 +11791,18 @@
               "null"
             ]
           },
-          "new_value": {},
-          "old_value": {}
+          "new_value": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "old_value": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         }
       },
       "AutomodActionType": {
@@ -15640,7 +15650,9 @@
             ],
             "maxLength": 152133
           },
-          "pull_request": {}
+          "pull_request": {
+            "type": "integer"
+          }
         },
         "required": [
           "id",


### PR DESCRIPTION
Adds missing types to allow client generation by
[openapi-generator](https://github.com/OpenAPITools/openapi-generator).

### To test:
```
docker run --rm -v ./:/local \
  openapitools/openapi-generator-cli \
  generate \
  -g rust \
  -o /local/output_directory \
  -i /local/discord-api-spec/specs/openapi.json
```