### PR TITLE
Fix nameplate palette schema

### DIFF
--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -32960,7 +32960,52 @@
       },
       "NameplatePalette": {
         "type": "string",
-        "oneOf": []
+        "oneOf": [
+          {
+            "title": "CRIMSON",
+            "const": "crimson"
+          },
+          {
+            "title": "BERRY",
+            "const": "berry"
+          },
+          {
+            "title": "SKY",
+            "const": "sky"
+          },
+          {
+            "title": "TEAL",
+            "const": "teal"
+          },
+          {
+            "title": "FOREST",
+            "const": "forest"
+          },
+          {
+            "title": "BUBBLE_GUM",
+            "const": "bubble_gum"
+          },
+          {
+            "title": "VIOLET",
+            "const": "violet"
+          },
+          {
+            "title": "COBALT",
+            "const": "cobalt"
+          },
+          {
+            "title": "CLOVER",
+            "const": "clover"
+          },
+          {
+            "title": "LEMON",
+            "const": "lemon"
+          },
+          {
+            "title": "WHITE",
+            "const": "white"
+          }
+        ]
       },
       "NewMemberActionResponse": {
         "type": "object",

--- a/specs/openapi_preview.json
+++ b/specs/openapi_preview.json
@@ -33058,7 +33058,52 @@
       },
       "NameplatePalette": {
         "type": "string",
-        "oneOf": []
+        "oneOf": [
+          {
+            "title": "CRIMSON",
+            "const": "crimson"
+          },
+          {
+            "title": "BERRY",
+            "const": "berry"
+          },
+          {
+            "title": "SKY",
+            "const": "sky"
+          },
+          {
+            "title": "TEAL",
+            "const": "teal"
+          },
+          {
+            "title": "FOREST",
+            "const": "forest"
+          },
+          {
+            "title": "BUBBLE_GUM",
+            "const": "bubble_gum"
+          },
+          {
+            "title": "VIOLET",
+            "const": "violet"
+          },
+          {
+            "title": "COBALT",
+            "const": "cobalt"
+          },
+          {
+            "title": "CLOVER",
+            "const": "clover"
+          },
+          {
+            "title": "LEMON",
+            "const": "lemon"
+          },
+          {
+            "title": "WHITE",
+            "const": "white"
+          }
+        ]
       },
       "NewMemberActionResponse": {
         "type": "object",


### PR DESCRIPTION
## Summary
- Replace the empty `NameplatePalette.oneOf` in both published specs with the documented palette constants.
- Keep `UserNameplateResponse.palette` as a string enum schema instead of an empty union.

Fixes #53

## Verification
- Parsed `specs/openapi.json` and `specs/openapi_preview.json` with Node.js.
- Checked `NameplatePalette` contains: `crimson`, `berry`, `sky`, `teal`, `forest`, `bubble_gum`, `violet`, `cobalt`, `clover`, `lemon`, `white`.
- Checked there are no empty `oneOf`/`anyOf` arrays reachable from `UserResponse`.